### PR TITLE
Add Radar for Frontend Components

### DIFF
--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -13,26 +13,26 @@ const config = {
     grid: "#bbb",
     inactive: "#ddd"
   },
-  title: "Procore Tech Radar",
+  title: "Frontend Components Radar",
   quadrants: [
-    { name: "Languages and Frameworks" },
-    { name: "Infrastructure" },
-    { name: "Tools" },
-    { name: "Data Management" }
+    { name: "Particles" },
+    { name: "Wrench" },
+    { name: "CORE" },
+    { name: "CORE Labs" }
   ],
   rings: [
-    { name: "ADOPT", color: "#93c47d" },
-    { name: "TRIAL", color: "#93d2c2" },
-    { name: "ASSESS", color: "#fbdb84" },
-    { name: "HOLD", color: "#efafa9" }
+    { name: "STABLE", color: "#93c47d" },
+    { name: "BETA", color: "#93d2c2" },
+    { name: "ALPHA", color: "#fbdb84" },
+    { name: "ABANDONED", color: "#efafa9" }
   ],
   print_layout: true,
   // zoomed_quadrant: 0,
   //ENTRIES
   entries: [
-    // Languages and Frameworks
+    // PARTICLES and Frameworks
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ADOPT,
       label: "JavaScript",
       active: true,
@@ -47,7 +47,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ADOPT,
       label: "React",
       active: true,
@@ -61,7 +61,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ADOPT,
       label: "Redux",
       active: true,
@@ -75,7 +75,7 @@ const config = {
         <a href="https://egghead.io/courses/getting-started-with-redux">Getting Started with Redux</a>
         and <a href="https://egghead.io/courses/building-react-applications-with-idiomatic-redux">idiomatic Redux</a>
         tutorials are a good starting point for new and experienced users.
-        Its minimal library design has spawned a rich set of tools, and we encourage you to check
+        Its minimal library design has spawned a rich set of CORE, and we encourage you to check
         out the <a href="https://github.com/markerikson/redux-ecosystem-links">redux-ecosystem-links</a>
         project for examples, middleware and utility libraries. We also particularly like the
         testability story: Dispatching actions, state transitions and rendering can be unit-tested
@@ -84,7 +84,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ADOPT,
       label: "Ruby",
       active: true,
@@ -93,7 +93,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ADOPT,
       label: "Rails",
       active: true,
@@ -102,7 +102,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.HOLD,
       label: "jQuery",
       active: true,
@@ -114,7 +114,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.LANGUAGES,
+      quadrant: QUADRANTS.PARTICLES,
       ring: RINGS.ASSESS,
       label: "TypeScript",
       active: true,
@@ -123,7 +123,7 @@ const config = {
     },
     // Infrastructure
     {
-      quadrant: QUADRANTS.INFRASTRUCTURE,
+      quadrant: QUADRANTS.WRENCH,
       ring: RINGS.ADOPT,
       label: "Docker",
       active: true,
@@ -131,9 +131,9 @@ const config = {
       description: ``,
       moved: 0
     },
-    // Tools
+    // CORE
     {
-      quadrant: QUADRANTS.TOOLS,
+      quadrant: QUADRANTS.CORE,
       ring: RINGS.ADOPT,
       label: "Webpack",
       active: true,
@@ -144,7 +144,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.TOOLS,
+      quadrant: QUADRANTS.CORE,
       ring: RINGS.ADOPT,
       label: "Babel",
       active: true,
@@ -155,7 +155,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.TOOLS,
+      quadrant: QUADRANTS.CORE,
       ring: RINGS.ADOPT,
       label: "Prettier",
       active: true,
@@ -164,7 +164,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.TOOLS,
+      quadrant: QUADRANTS.CORE,
       ring: RINGS.ADOPT,
       label: "Jest",
       active: true,
@@ -173,7 +173,7 @@ const config = {
       moved: 0
     },
     {
-      quadrant: QUADRANTS.TOOLS,
+      quadrant: QUADRANTS.CORE,
       ring: RINGS.HOLD,
       label: "Mocha",
       active: true,
@@ -184,9 +184,8 @@ const config = {
       moved: 0
     },
     // Data Management
-    // Data Management
     {
-      quadrant: QUADRANTS.DATA_MANAGEMENT,
+      quadrant: QUADRANTS.CORE_LABS,
       ring: RINGS.ADOPT,
       label: "Postgresql",
       active: true,
@@ -195,7 +194,6 @@ const config = {
       moved: 0
     }
   ]
-  //ENTRIES
 };
 
 radar_visualization(config);

--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -391,16 +391,314 @@ const config = {
       description: '',
       moved: 0
     },
-    // Infrastructure
+    // Wrench
     {
       quadrant: QUADRANTS.WRENCH,
-      ring: RINGS.STABLE,
-      label: "Docker",
+      ring: RINGS.ABANDONED,
+      label: "ActionButton",
       active: true,
       link: null,
       description: '',
       moved: 0
     },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "AssigneePicker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "AttachmentManager",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Batch Editor",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Bluebeam Modal Form",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Breadcrumbs",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "Bulk Attacher",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Button",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Callout List",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Charting",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Checkbox",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Checkbox Dropdown",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Date Picker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.BETA,
+      label: "Date Range Picker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Dropdown Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Empty State",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "Feedback Button",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "File Tokens",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "Filters",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ALPHA,
+      label: "Flip Card",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "FormSelect",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "Location Picker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Modal",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "MultiToken Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "PayApp Table",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Quick Adder",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Paginator",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Panel",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Scrim",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Search Box",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Scroll Bar",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Token Picker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.ABANDONED,
+      label: "Sub Tabs",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.WRENCH,
+      ring: RINGS.STABLE,
+      label: "Wrench Indicator",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+
     // CORE
     {
       quadrant: QUADRANTS.CORE,

--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -30,111 +30,381 @@ const config = {
   // zoomed_quadrant: 0,
   //ENTRIES
   entries: [
-    // PARTICLES and Frameworks
+    // PARTICLES
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ADOPT,
-      label: "JavaScript",
+      ring: RINGS.ABANDONED,
+      label: "Breadcrumb",
       active: true,
       link: null,
-      description: `
-        JavaScript® (often shortened to JS) is a lightweight, interpreted, object-oriented language
-        with first-class functions, and is best known as the scripting language for Web pages, but
-        it's used in many non-browser environments as well. It is a prototype-based, multi-paradigm
-        scripting language that is dynamic, and supports object-oriented, imperative, and functional
-        programming styles. It is the only programming language that runs natively in browsers.
-      `,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ADOPT,
-      label: "React",
+      ring: RINGS.ALPHA,
+      label: "Bulk Editor",
       active: true,
       link: null,
-      description: `
-        <a href="http://reactjs.org">React.js</a> stands out due to its design around a reactive
-        data flow. Allowing only one-way data binding greatly simplifies the rendering logic and
-        avoids many of the issues that commonly plague applications written with other frameworks.
-        It has become our library of choice for building user interfaces on the web.
-      `,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ADOPT,
-      label: "Redux",
+      ring: RINGS.STABLE,
+      label: "Calendar",
       active: true,
       link: null,
-      description: `
-        With the increasing complexity of single-page JavaScript applications, we have seen a more
-        pressing need to make client-side state management predictable.
-        <a href="http://redux.js.org/"><strong>Redux</strong></a>, with its
-        <a href="http://redux.js.org/docs/introduction/ThreePrinciples.html">three principles</a>
-        of restrictions for updating state, has proven to be invaluable in our applications.
-        <a href="https://egghead.io/courses/getting-started-with-redux">Getting Started with Redux</a>
-        and <a href="https://egghead.io/courses/building-react-applications-with-idiomatic-redux">idiomatic Redux</a>
-        tutorials are a good starting point for new and experienced users.
-        Its minimal library design has spawned a rich set of CORE, and we encourage you to check
-        out the <a href="https://github.com/markerikson/redux-ecosystem-links">redux-ecosystem-links</a>
-        project for examples, middleware and utility libraries. We also particularly like the
-        testability story: Dispatching actions, state transitions and rendering can be unit-tested
-        separately from one another and with minimal amounts of mocking.
-      `,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ADOPT,
-      label: "Ruby",
+      ring: RINGS.ABANDONED,
+      label: "Checkbox",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ADOPT,
-      label: "Rails",
+      ring: RINGS.BETA,
+      label: "Coach Marks",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.HOLD,
-      label: "jQuery",
+      ring: RINGS.ABANDONED,
+      label: "CollapsibleTabHeader",
       active: true,
       link: null,
-      description: `
-        jQuery was extremely important when introduced, and instrumental in pushing the client-side
-        web forward, but its role has since been filled by more robust alternatives.
-      `,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.PARTICLES,
-      ring: RINGS.ASSESS,
-      label: "TypeScript",
+      ring: RINGS.STABLE,
+      label: "Configurable Field Set",
       active: true,
       link: null,
-      description: ``
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "CRUD Permissions Table",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Dashboard",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Date Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Dialog",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Feedback Banner",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "File Explorer",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Filters",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Info Grid",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "List Adder",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "List Partial",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Modal",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.BETA,
+      label: "Navigation Tiers",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Notification Bar",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.BETA,
+      label: "Overflow Menu",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Paginator",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.BETA,
+      label: "Phone Input",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Radio",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ALPHA,
+      label: "Scoped Scroll",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ALPHA,
+      label: "Search Bar",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Sidebar List",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Spinner",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.BETA,
+      label: "Sticky Footer",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Table Row Adder",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Table View Control",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Table",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Tabs",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Text Input",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.STABLE,
+      label: "Tiered Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.BETA,
+      label: "Tiny MCE",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Token",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Tooltip",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.PARTICLES,
+      ring: RINGS.ABANDONED,
+      label: "Uploader",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
     },
     // Infrastructure
     {
       quadrant: QUADRANTS.WRENCH,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Docker",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     },
     // CORE
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Webpack",
       active: true,
       link: null,
@@ -145,52 +415,52 @@ const config = {
     },
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Babel",
       active: true,
       link: null,
       description: `
-        Babel.js has become the default compiler for writing next-generation JavaScript. Its ecosystem is huge, thanks to its plugin system. It allows developers to write ES6+ code that runs in the browser or on the server without sacrificing backward compatibility for older browsers, and with very little configuration. It has first-class support for different build-and-test systems, which makes integration with any current workflow simple. It is a great piece of software that has become the main driver of new language feature adoption and innovation.
+        Babel.js has become the default compiler for writing next-generation JavaScript. Its ecosystem is huge, thanks to its plugin system. It allows developers to write ES6+ code that runs in the browser or on the server without sacrificing backward compatibility for older browsers, and with very little configuration. It has first-class support for different build-and-test systems, which makes integration with any current workflow simple. It is a great piece of software that has become the main driver of new language feature STABLEion and innovation.
       `,
       moved: 0
     },
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Prettier",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Jest",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     },
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.HOLD,
+      ring: RINGS.ABANDONED,
       label: "Mocha",
       active: true,
       link: null,
       description: `
-        Mocha is a capable and well-adopted test runner, but we have found that Jest provides a superior feature set and developer experience.
+        Mocha is a capable and well-STABLEed test runner, but we have found that Jest provides a superior feature set and developer experience.
       `,
       moved: 0
     },
     // Data Management
     {
       quadrant: QUADRANTS.CORE_LABS,
-      ring: RINGS.ADOPT,
+      ring: RINGS.STABLE,
       label: "Postgresql",
       active: true,
       link: null,
-      description: ``,
+      description: '',
       moved: 0
     }
   ]

--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -703,29 +703,16 @@ const config = {
     {
       quadrant: QUADRANTS.CORE,
       ring: RINGS.STABLE,
-      label: "Webpack",
+      label: "Avatar",
       active: true,
       link: null,
-      description: `
-        Webpack is the dominant tool for bundling various module formats into a format compatible with browsers. Webpack's paradigm is to treat everything as a module, using purpose-built loaders to transform non-module files into modules. It is further extensible via its plugin system.
-      `,
+      description: ``,
       moved: 0
     },
     {
       quadrant: QUADRANTS.CORE,
       ring: RINGS.STABLE,
-      label: "Babel",
-      active: true,
-      link: null,
-      description: `
-        Babel.js has become the default compiler for writing next-generation JavaScript. Its ecosystem is huge, thanks to its plugin system. It allows developers to write ES6+ code that runs in the browser or on the server without sacrificing backward compatibility for older browsers, and with very little configuration. It has first-class support for different build-and-test systems, which makes integration with any current workflow simple. It is a great piece of software that has become the main driver of new language feature STABLEion and innovation.
-      `,
-      moved: 0
-    },
-    {
-      quadrant: QUADRANTS.CORE,
-      ring: RINGS.STABLE,
-      label: "Prettier",
+      label: "Badge",
       active: true,
       link: null,
       description: '',
@@ -734,7 +721,7 @@ const config = {
     {
       quadrant: QUADRANTS.CORE,
       ring: RINGS.STABLE,
-      label: "Jest",
+      label: "Banner",
       active: true,
       link: null,
       description: '',
@@ -742,13 +729,290 @@ const config = {
     },
     {
       quadrant: QUADRANTS.CORE,
-      ring: RINGS.ABANDONED,
-      label: "Mocha",
+      ring: RINGS.STABLE,
+      label: "Breadcrumbs",
       active: true,
       link: null,
-      description: `
-        Mocha is a capable and well-STABLEed test runner, but we have found that Jest provides a superior feature set and developer experience.
-      `,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Button",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Calendar",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Card",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Checkbox",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Dropdown",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Empty State",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Field",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Font",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Header",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Icon",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Input",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Link",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Menu",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Modal",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Notation",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Overlay Trigger",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Pagination",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Popover",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Portal",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "RadioButton",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Search",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Segmented Controller",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Spinner",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Switch",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Table",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Tabs",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "TextArea",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Toast",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Token",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE,
+      ring: RINGS.STABLE,
+      label: "Tooltip",
+      active: true,
+      link: null,
+      description: '',
       moved: 0
     },
     // CORE Labs

--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -751,16 +751,232 @@ const config = {
       `,
       moved: 0
     },
-    // Data Management
+    // CORE Labs
     {
       quadrant: QUADRANTS.CORE_LABS,
-      ring: RINGS.STABLE,
-      label: "Postgresql",
+      ring: RINGS.ALPHA,
+      label: "Accordion",
       active: true,
       link: null,
       description: '',
       moved: 0
-    }
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "Activity Feed",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Bugsnag Provider",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ABANDONED,
+      label: "Card Board",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "Content Placeholder",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Date Picker",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ALPHA,
+      label: "Dropdown Select",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "File Attacher",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ABANDONED,
+      label: "File Explorer",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "File Browser",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "File Viewer",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Financials Utils",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Highcharts Visuals",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "List Viewer",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Markup Toolbars",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "Master Detail",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Mentions",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.BETA,
+      label: "MultiStep Manager",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Pakaukau",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "PhraseApp Editor",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ALPHA,
+      label: "Signature Slider",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ALPHA,
+      label: "Star Rating",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Toast Alert",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.ALPHA,
+      label: "Tree",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.CORE_LABS,
+      ring: RINGS.STABLE,
+      label: "Virtualized",
+      active: true,
+      link: null,
+      description: '',
+      moved: 0
+    },
   ]
 };
 

--- a/public/core-components/config.js
+++ b/public/core-components/config.js
@@ -1,0 +1,201 @@
+import { QUADRANTS, RINGS } from "./constants.js";
+
+const config = {
+  svg_id: "radar",
+  width: 1450,
+  height: 1000,
+  description: {
+    width: 300,
+    height: 300
+  },
+  colors: {
+    background: "#fff",
+    grid: "#bbb",
+    inactive: "#ddd"
+  },
+  title: "Procore Tech Radar",
+  quadrants: [
+    { name: "Languages and Frameworks" },
+    { name: "Infrastructure" },
+    { name: "Tools" },
+    { name: "Data Management" }
+  ],
+  rings: [
+    { name: "ADOPT", color: "#93c47d" },
+    { name: "TRIAL", color: "#93d2c2" },
+    { name: "ASSESS", color: "#fbdb84" },
+    { name: "HOLD", color: "#efafa9" }
+  ],
+  print_layout: true,
+  // zoomed_quadrant: 0,
+  //ENTRIES
+  entries: [
+    // Languages and Frameworks
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ADOPT,
+      label: "JavaScript",
+      active: true,
+      link: null,
+      description: `
+        JavaScript® (often shortened to JS) is a lightweight, interpreted, object-oriented language
+        with first-class functions, and is best known as the scripting language for Web pages, but
+        it's used in many non-browser environments as well. It is a prototype-based, multi-paradigm
+        scripting language that is dynamic, and supports object-oriented, imperative, and functional
+        programming styles. It is the only programming language that runs natively in browsers.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ADOPT,
+      label: "React",
+      active: true,
+      link: null,
+      description: `
+        <a href="http://reactjs.org">React.js</a> stands out due to its design around a reactive
+        data flow. Allowing only one-way data binding greatly simplifies the rendering logic and
+        avoids many of the issues that commonly plague applications written with other frameworks.
+        It has become our library of choice for building user interfaces on the web.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ADOPT,
+      label: "Redux",
+      active: true,
+      link: null,
+      description: `
+        With the increasing complexity of single-page JavaScript applications, we have seen a more
+        pressing need to make client-side state management predictable.
+        <a href="http://redux.js.org/"><strong>Redux</strong></a>, with its
+        <a href="http://redux.js.org/docs/introduction/ThreePrinciples.html">three principles</a>
+        of restrictions for updating state, has proven to be invaluable in our applications.
+        <a href="https://egghead.io/courses/getting-started-with-redux">Getting Started with Redux</a>
+        and <a href="https://egghead.io/courses/building-react-applications-with-idiomatic-redux">idiomatic Redux</a>
+        tutorials are a good starting point for new and experienced users.
+        Its minimal library design has spawned a rich set of tools, and we encourage you to check
+        out the <a href="https://github.com/markerikson/redux-ecosystem-links">redux-ecosystem-links</a>
+        project for examples, middleware and utility libraries. We also particularly like the
+        testability story: Dispatching actions, state transitions and rendering can be unit-tested
+        separately from one another and with minimal amounts of mocking.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ADOPT,
+      label: "Ruby",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ADOPT,
+      label: "Rails",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.HOLD,
+      label: "jQuery",
+      active: true,
+      link: null,
+      description: `
+        jQuery was extremely important when introduced, and instrumental in pushing the client-side
+        web forward, but its role has since been filled by more robust alternatives.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.LANGUAGES,
+      ring: RINGS.ASSESS,
+      label: "TypeScript",
+      active: true,
+      link: null,
+      description: ``
+    },
+    // Infrastructure
+    {
+      quadrant: QUADRANTS.INFRASTRUCTURE,
+      ring: RINGS.ADOPT,
+      label: "Docker",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    },
+    // Tools
+    {
+      quadrant: QUADRANTS.TOOLS,
+      ring: RINGS.ADOPT,
+      label: "Webpack",
+      active: true,
+      link: null,
+      description: `
+        Webpack is the dominant tool for bundling various module formats into a format compatible with browsers. Webpack's paradigm is to treat everything as a module, using purpose-built loaders to transform non-module files into modules. It is further extensible via its plugin system.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.TOOLS,
+      ring: RINGS.ADOPT,
+      label: "Babel",
+      active: true,
+      link: null,
+      description: `
+        Babel.js has become the default compiler for writing next-generation JavaScript. Its ecosystem is huge, thanks to its plugin system. It allows developers to write ES6+ code that runs in the browser or on the server without sacrificing backward compatibility for older browsers, and with very little configuration. It has first-class support for different build-and-test systems, which makes integration with any current workflow simple. It is a great piece of software that has become the main driver of new language feature adoption and innovation.
+      `,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.TOOLS,
+      ring: RINGS.ADOPT,
+      label: "Prettier",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.TOOLS,
+      ring: RINGS.ADOPT,
+      label: "Jest",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    },
+    {
+      quadrant: QUADRANTS.TOOLS,
+      ring: RINGS.HOLD,
+      label: "Mocha",
+      active: true,
+      link: null,
+      description: `
+        Mocha is a capable and well-adopted test runner, but we have found that Jest provides a superior feature set and developer experience.
+      `,
+      moved: 0
+    },
+    // Data Management
+    // Data Management
+    {
+      quadrant: QUADRANTS.DATA_MANAGEMENT,
+      ring: RINGS.ADOPT,
+      label: "Postgresql",
+      active: true,
+      link: null,
+      description: ``,
+      moved: 0
+    }
+  ]
+  //ENTRIES
+};
+
+radar_visualization(config);

--- a/public/core-components/constants.js
+++ b/public/core-components/constants.js
@@ -1,8 +1,8 @@
 export const QUADRANTS = {
-  LANGUAGES: 0,
-  INFRASTRUCTURE: 1,
-  TOOLS: 2,
-  DATA_MANAGEMENT: 3
+  PARTICLES: 0,
+  WRENCH: 1,
+  CORE: 2,
+  CORE_LABS: 3
 };
 
 export const RINGS = {

--- a/public/core-components/constants.js
+++ b/public/core-components/constants.js
@@ -1,0 +1,13 @@
+export const QUADRANTS = {
+  LANGUAGES: 0,
+  INFRASTRUCTURE: 1,
+  TOOLS: 2,
+  DATA_MANAGEMENT: 3
+};
+
+export const RINGS = {
+  ADOPT: 0,
+  TRIAL: 1,
+  ASSESS: 2,
+  HOLD: 3
+};

--- a/public/core-components/constants.js
+++ b/public/core-components/constants.js
@@ -6,8 +6,8 @@ export const QUADRANTS = {
 };
 
 export const RINGS = {
-  ADOPT: 0,
-  TRIAL: 1,
-  ASSESS: 2,
-  HOLD: 3
+  STABLE: 0,
+  BETA: 1,
+  ALPHA: 2,
+  ABANDONED: 3
 };

--- a/public/core-components/index.html
+++ b/public/core-components/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
-    <title>Procore Tech Radar</title>
+    <title>CORE Components Radar</title>
     <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" href="../radar.css">
   </head>
@@ -15,10 +15,10 @@
             The Procore Tech Radar is a list of technologies, complemented by an assessment result, called <em>ring assignment</em>. We use four rings with the following semantics:
           </p>
           <ul>
-            <li><strong>ADOPT</strong> &mdash; Technologies we have high confidence in to serve our purpose, also in large scale. Technologies with a usage culture in our Procore production environment, low risk and recommended to be widely used.</li>
-            <li><strong>TRIAL</strong> &mdash; Technologies that we have seen work with success in project work to solve a real problem; first serious usage experience that confirm benefits and can uncover limitations. TRIAL technologies are slightly more risky; some engineers in our organization walked this path and will share knowledge and experiences.</li>
-            <li><strong>ASSESS</strong> &mdash; Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. ASSESS technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.</li>
-            <li><strong>HOLD</strong> &mdash; Technologies not recommended to be used for new projects. Technologies that we think are not (yet) worth to (further) invest in, or have been obsolesced by better choices. HOLD technologies should not be used for new projects, but usually can be continued for existing projects.</li>
+            <li><strong>STABLE</strong> &mdash; Technologies we have high confidence in to serve our purpose, also in large scale. Technologies with a usage culture in our Procore production environment, low risk and recommended to be widely used.</li>
+            <li><strong>BETA</strong> &mdash; Technologies that we have seen work with success in project work to solve a real problem; first serious usage experience that confirm benefits and can uncover limitations. TRIAL technologies are slightly more risky; some engineers in our organization walked this path and will share knowledge and experiences.</li>
+            <li><strong>ALPHA</strong> &mdash; Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. ASSESS technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.</li>
+            <li><strong>ABANDONED</strong> &mdash; Technologies not recommended to be used for new projects. Technologies that we think are not (yet) worth to (further) invest in, or have been obsolesced by better choices. HOLD technologies should not be used for new projects, but usually can be continued for existing projects.</li>
           </ul>
         </td>
         <td>

--- a/public/core-components/index.html
+++ b/public/core-components/index.html
@@ -1,0 +1,41 @@
+<html>
+  <head>
+    <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+    <title>Procore Tech Radar</title>
+    <link rel="shortcut icon" href="favicon.ico">
+    <link rel="stylesheet" href="../radar.css">
+  </head>
+  <body>
+    <svg id="radar"></svg>
+    <table>
+      <tr>
+        <td>
+          <h3>What is the Tech Radar?</h3>
+          <p>
+            The Procore Tech Radar is a list of technologies, complemented by an assessment result, called <em>ring assignment</em>. We use four rings with the following semantics:
+          </p>
+          <ul>
+            <li><strong>ADOPT</strong> &mdash; Technologies we have high confidence in to serve our purpose, also in large scale. Technologies with a usage culture in our Procore production environment, low risk and recommended to be widely used.</li>
+            <li><strong>TRIAL</strong> &mdash; Technologies that we have seen work with success in project work to solve a real problem; first serious usage experience that confirm benefits and can uncover limitations. TRIAL technologies are slightly more risky; some engineers in our organization walked this path and will share knowledge and experiences.</li>
+            <li><strong>ASSESS</strong> &mdash; Technologies that are promising and have clear potential value-add for us; technologies worth to invest some research and prototyping efforts in to see if it has impact. ASSESS technologies have higher risks; they are often brand new and highly unproven in our organisation. You will find some engineers that have knowledge in the technology and promote it, you may even find teams that have started a prototyping effort.</li>
+            <li><strong>HOLD</strong> &mdash; Technologies not recommended to be used for new projects. Technologies that we think are not (yet) worth to (further) invest in, or have been obsolesced by better choices. HOLD technologies should not be used for new projects, but usually can be continued for existing projects.</li>
+          </ul>
+        </td>
+        <td>
+          <h3>What is the purpose?</h3>
+          <p>
+            The Tech Radar is a tool to inspire and support engineering teams at Procore to pick the best technologies for new projects; it provides a platform to share knowledge and experience in technologies, to reflect on technology decisions and continuously evolve our technology landscape. Based on the <a href="https://www.thoughtworks.com/radar">pioneering work of ThoughtWorks</a>, our Tech Radar sets out the changes in technologies that are interesting in software development &mdash; changes that we think our engineering teams should pay attention to and consider using in their projects.
+          </p>
+          <h3>How do we maintain it?</h3>
+          <p>
+            The Tech Radar is maintained by the <em>Procore Technologists Guild</em> &mdash; an open group of  senior Procore technologists committed to devote time to the Tech Radar purpose. The guild self organises to maintain the Tech Radar documents, including this public version. Assignment of technologies to rings is the outcome of ring change proposals, which are discussed and voted on in guild meetings. The Tech Radar depends on active participation and input from all engineering teams at Procore.
+          </p>
+        </td>
+      </tr>
+    </table>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/1.0.9/purify.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/4.13.0/d3.min.js"></script>
+    <script src="../radar.js"></script>
+    <script src="config.js" type="module"></script>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -7,5 +7,6 @@
   </head>
   <body>
     <a href="financials">Construction Financials Radar</a>
+    <a href="core-components">CORE Components Radar</a>
   </body>
 </html>


### PR DESCRIPTION
### Summary
With so many shared frontend components, spread across several repos, it can be hard to know what is safe to use vs. what we are working to deprecate. By plotting them all on a radar, it will make it easy to see a landscape of what's available and get a opinion about the component you plan to use. This will be increasingly important as we scale the organization and for new hires who don't have context of when/how things were built.

### Screenshot
<img width="1624" alt="screen shot 2019-02-20 at 4 15 40 pm" src="https://user-images.githubusercontent.com/8366399/53134248-3aed3200-352b-11e9-9236-fbb1fba435d5.png">

### Open Questions

1. Do we like the 4 quadrant names? (Wrench, Particles, CORE Labs, CORE)
- Are there any missing? or should we pick a different categorization?

2. Do we like the 4 ring names? (ABANDONED, ALPHA, BETA, STABLE)
We plan to use this naming in the docs for CORE Labs and figured it makes sense more broadly.
- Do we instead prefer the more generic ones? (HOLD, ASSESS, TRIAL, ADOPT)
- Are there even better names?
- Should we consider more/fewer rings than 4?

3. Should we roll this up into a general frontend radar? (Components, Tools/Libraries, Languages/Frameworks, Other)
NOTE: My opinion is no. I think there is enough content just in the component space, that a specific radar is warranted.

### Next Steps
1. Cleanup the CSS to fix the style issues/collisions
2. Add descriptions to components
3. Update components (either ones in the incorrect sector or ones that are missing)